### PR TITLE
Código duplicado entre "FitNeuralNetwork" e "ApplyTraining".

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -1,10 +1,10 @@
 #Deve-se passar o caminho para o xlsx da região para qual o modelo deve ser TREINADO
 from NeuralNetwork.NeuralNetwork import ApplyTraining, FitNeuralNetwork
 
-model = FitNeuralNetwork('./Data/spei12_riopardodeminas.xlsx', "Rio Pardo")
+model, trainData, testData, monthTrainData, monthTestData, split, trainDataForPrediction, trainDataTrueValues, testDataForPrediction, testDataTrueValues, trainMonthsForPrediction, trainMonthForPredictedValues, testMonthsForPrediction, testMonthForPredictedValues = FitNeuralNetwork('./Data/spei12_riopardodeminas.xlsx', "Rio Pardo")
 
-#Deve-se passar o caminho para o xlsx, o nome da Região e o modelo treinado;
-ApplyTraining("./Data/spei12_FranciscoSá.xlsx", "Francisco Sá", model)
+#Deve-se passar o caminho para o xlsx, o nome da RegiÃ£o e o modelo treinado;
+ApplyTraining("./Data/spei12_FranciscoSÃ¡.xlsx", "Francisco SÃ¡", model, trainData, testData, monthTrainData, monthTestData, split, trainDataForPrediction, trainDataTrueValues, testDataForPrediction, testDataTrueValues, trainMonthsForPrediction, trainMonthForPredictedValues, testMonthsForPrediction, testMonthForPredictedValues)
 #ApplyTraining("./Data/spei12_GrãoMogol.xlsx", "Grão Mogol", model)
 #ApplyTraining("./Data/spei12_Josenopolis.xlsx", "Josenópolis", model)
 

--- a/NeuralNetwork/NeuralNetwork.py
+++ b/NeuralNetwork/NeuralNetwork.py
@@ -98,15 +98,7 @@ def FitNeuralNetwork(xlsx, regionName):
 
     return model
 
-def ApplyTraining(xlsx, regionName, model):
-
-    trainData, testData, monthTrainData, monthTestData, split = splitSpeiData(xlsx)
-
-    trainDataForPrediction, trainDataTrueValues = cria_IN_OUT(trainData, totalPoints)
-    testDataForPrediction, testDataTrueValues = cria_IN_OUT(testData, totalPoints)
-
-    trainMonthsForPrediction, trainMonthForPredictedValues = cria_IN_OUT(monthTrainData, totalPoints)
-    testMonthsForPrediction, testMonthForPredictedValues = cria_IN_OUT(monthTestData, totalPoints)
+def ApplyTraining(xlsx, regionName, model, trainData, testData, monthTrainData, monthTestData, split, trainDataForPrediction, trainDataTrueValues, testDataForPrediction, testDataTrueValues, trainMonthsForPrediction, trainMonthForPredictedValues, testMonthsForPrediction, testMonthForPredictedValues):
 
     trainPredictValues = model.predict(trainDataForPrediction)
     testPredictValues = model.predict(testDataForPrediction)


### PR DESCRIPTION
Opção por repassar as variáveis como parâmetros entre as duas funções.

As variáveis a seguir têm sido declaradas em uma função, descartadas, e declaradas de novo em outra função: trainData, testData, monthTrainData, monthTestData, split, trainDataForPrediction, trainDataTrueValues, testDataForPrediction, testDataTrueValues, trainMonthsForPrediction, trainMonthForPredictedValues, testMonthsForPrediction, testMonthForPredictedValues.