### PR TITLE
`NeuralNetwork.py`: defining the input shape on a separate line

### DIFF
--- a/NeuralNetwork/NeuralNetwork.py
+++ b/NeuralNetwork/NeuralNetwork.py
@@ -18,7 +18,8 @@ hiddenUnits = dados_json['hiddenUnits']
 
 def createNeuralNetwork(hidden_units, dense_units, input_shape, activation):
     model = tf.keras.Sequential()   
-    model.add(tf.keras.layers.LSTM(hidden_units,input_shape=input_shape,activation=activation[0]))
+    model.add(tf.keras.Input(shape=input_shape))
+    model.add(tf.keras.layers.LSTM(hidden_units,activation=activation[0]))
     model.add(tf.keras.layers.Dense(units=dense_units,activation=activation[1]))
     model.add(tf.keras.layers.Dense(units=dense_units,activation=activation[1]))
     model.add(tf.keras.layers.Dense(units=dense_units,activation=activation[1]))


### PR DESCRIPTION
Solves the following error:

> UserWarning: Do not pass an `input_shape`/`input_dim` argument to a layer. When using Sequential models, prefer using an `Input(shape)` object as the first layer in the model instead.
>   super().__init__(**kwargs)
> None